### PR TITLE
Fix for creating new vterm buffer

### DIFF
--- a/helm-switch-shell.el
+++ b/helm-switch-shell.el
@@ -159,7 +159,7 @@
     (eshell (eshell t))
     (shell (helm-switch-shell--new-shell))
     (vterm (if (fboundp 'vterm)
-               (vterm)
+               (vterm t)
              (message "emacs-libvterm not installed")))
     (shell-select (helm-switch-shell--shell-select))))
 


### PR DESCRIPTION
calling (vterm) without an argument just switches back an already existing buffer, (vterm t) actually creates a new vterm-buffer.